### PR TITLE
Added PublishProfile support.

### DIFF
--- a/SlowCheetah/Resources/Install/SlowCheetah.Transforms.targets
+++ b/SlowCheetah/Resources/Install/SlowCheetah.Transforms.targets
@@ -89,10 +89,17 @@ Copyright (C) Sayed Ibrahim Hashimi, Chuck England 2011-2013. All rights reserve
     <MakeDir Directories="@(_TmpLinkFiles->'$(OutDir)%(RelativeDir)')"
                  Condition=" '%(Link)'!='' " />
 
-    <SlowCheetah.Xdt.TransformXml Source="@(_AppConfigToTransform->'%(FullPath)')"
-                  Transform="%(RelativeDir)%(Filename).$(Configuration)%(Extension)"
-                  Destination="$(_AppConfigDest)"
-                  Condition=" Exists('%(RelativeDir)%(Filename).$(Configuration)%(Extension)') " />
+    <!-- use Configuration transform, if it exists -->
+    <SlowCheetah.Xdt.TransformXml 
+              Source="$(_AppConfigDest)" Destination="$(_AppConfigDest)"
+              Transform="@(_AppConfigToTransform->'%(RelativeDir)%(Filename).$(Configuration)%(Extension)')"
+              Condition=" Exists(@(_AppConfigToTransform->'%(RelativeDir)%(Filename).$(Configuration)%(Extension)')) " />
+
+    <!-- use PublishProfile transform, if it exists -->
+    <SlowCheetah.Xdt.TransformXml
+              Source="$(_AppConfigDest)" Destination="$(_AppConfigDest)"
+              Transform="@(_AppConfigToTransform->'%(RelativeDir)%(Filename).$(PublishProfile)%(Extension)')"
+              Condition=" Exists(@(_AppConfigToTransform->'%(RelativeDir)%(Filename).$(PublishProfile)%(Extension)')) " />
 
     <!-- 
     For link files this will write the transformed file into the 


### PR DESCRIPTION
This functions the same way as web applications; in other words, app.config => app.(Configuration).config => app.(PublishProfile).config.
The transforms happen in-place, as the app.config gets copied to the destination before this task is called. Fixes #86 
