### PR TITLE
Fix for issue with Teamcity erroring out with a "dll missing" error

### DIFF
--- a/SlowCheetah/Resources/Install/SlowCheetah.Transforms.targets
+++ b/SlowCheetah/Resources/Install/SlowCheetah.Transforms.targets
@@ -18,7 +18,11 @@ Copyright (C) Sayed Ibrahim Hashimi, Chuck England 2011-2013. All rights reserve
     <sc-MSBuildLibPathLocal Condition=" '$(sc-MSBuildLibPathLocal)'=='' ">$(LocalAppData)\Microsoft\MSBuild\SlowCheetah\v2.5.10.2\</sc-MSBuildLibPathLocal>
   </PropertyGroup>
 
-  <Target Name="CopyAssembliesToLocalPath" Condition=" '$(sc-MSBuildLibPathLocal)'!='' and !Exists('$(sc-MSBuildLibPathLocal)')">
+  <ItemGroup>
+    <LocalAppDataFiles Include="$(sc-MSBuildLibPathLocal)**\*" />
+  </ItemGroup>
+
+  <Target Name="CopyAssembliesToLocalPath" Condition=" '$(sc-MSBuildLibPathLocal)'!='' and ( !Exists('$(sc-MSBuildLibPathLocal)') or '@(LocalAppDataFiles)'=='' )">
     <ItemGroup>
       <_FilesToCopy Remove="@(_FilesToCopy)"/>
       <_FilesToCopy Include="$(SlowCheetahToolsPath)Microsoft.Web.XmlTransform.dll"/>


### PR DESCRIPTION
I have been looking at this issue the past couple of days. I have noticed there are a few issues in the log (e.g. #114) about this, but no concrete solution.
I spent a bit of time to understand what's going on and I think I've cracked it... famous last words.
The condition for copying the files checks if the directory exists, but not if it has any files. In my case (and some others in those issues) the directory existed, but had no files for some reason.
By adding a check for the existence of files, it all worked automagically.

I don't have an answer why there were no files in the directory in the first place. My best guess is that because I encountered the issue with the package not being there (before I implemented a nuget restore in the build) the whole thing was left in a half baked state.

(I believe that's the reason a lot of commenters said it worked after they renamed the directory or "fixed" the version number in the targets file. Renaming the directory to .3 would mean the condition would be satisfied and the dir and files created. The same with changing the version number in the targets file)
