### PR TITLE
Use nuget tools for CI builds

### DIFF
--- a/SlowCheetah/Resources/Install/SlowCheetah.Transforms.targets
+++ b/SlowCheetah/Resources/Install/SlowCheetah.Transforms.targets
@@ -15,7 +15,7 @@ Copyright (C) Sayed Ibrahim Hashimi, Chuck England 2011-2013. All rights reserve
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
   <PropertyGroup>
-    <sc-MSBuildLibPathLocal Condition=" '$(sc-MSBuildLibPathLocal)'=='' ">$([System.IO.Path]::GetFullPath( $(MSBuildProjectDirectory)\..\packages\SlowCheetah.2.5.10.3\tools\))</sc-MSBuildLibPathLocal>
+    <sc-MSBuildLibPathLocal Condition=" '$(sc-MSBuildLibPathLocal)'=='' ">$([System.IO.Path]::GetFullPath( $(MSBuildProjectDirectory)\..\packages\SlowCheetah.2.5.10.2\tools\))</sc-MSBuildLibPathLocal>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi,

To allow a project to build without having to install the VSIX on the build server I think the targets file could be changed.
The change worked for me for the v2.5.10.3 NuGet package.

The version number in source is v2.5.10.2 however. Is that on another branch oslt?
