### PR TITLE
Apply PublishProfile transformation in non-web projects

### DIFF
--- a/SlowCheetah/Resources/Install/SlowCheetah.Transforms.targets
+++ b/SlowCheetah/Resources/Install/SlowCheetah.Transforms.targets
@@ -146,13 +146,21 @@ Copyright (C) Sayed Ibrahim Hashimi, Chuck England 2011-2013. All rights reserve
 
     <PropertyGroup>
       <_Sc_HasAppConfigTransform>false</_Sc_HasAppConfigTransform>
-      <_Sc_HasAppConfigTransform Condition=" Exists( '@(_AppConfigToTransform->'%(RelativeDir)%(Filename).$(Configuration)%(Extension)')' ) ">true</_Sc_HasAppConfigTransform>
+      <_Sc_HasAppConfigConfigurationTransform Condition=" Exists( '@(_AppConfigToTransform->'%(RelativeDir)%(Filename).$(Configuration)%(Extension)')' ) ">true</_Sc_HasAppConfigConfigurationTransform>
+      <_Sc_HasAppConfigPublishProfileTransform Condition=" Exists( '@(_AppConfigToTransform->'%(RelativeDir)%(Filename).$(PublishProfile)%(Extension)')' ) ">true</_Sc_HasAppConfigPublishProfileTransform>
+      <_Sc_HasAppConfigPublishProfileTransform Condition=" '$(Configuration)'=='$(PublishProfile)' ">false</_Sc_HasAppConfigPublishProfileTransform>
+      <_Sc_HasAppConfigTransform Condition=" '$(_Sc_HasAppConfigConfigurationTransform)'=='true' ">true</_Sc_HasAppConfigTransform>
+      <_Sc_HasAppConfigTransform Condition=" '$(_Sc_HasAppConfigPublishProfileTransform)'=='true' ">true</_Sc_HasAppConfigTransform>
     </PropertyGroup>
     <Message Text="Tasks path: $(SlowCheetahTaskPath)" Importance="low"/>
     <SlowCheetah.Xdt.TransformXml Source="$(AppConfig)"
                   Transform="@(_AppConfigToTransform->'%(RelativeDir)%(Filename).$(Configuration)%(Extension)')"
                   Destination="$(__SC_IntermediateAppConfig)"
-                  Condition=" '$(_Sc_HasAppConfigTransform)'=='true' " />
+                  Condition=" '$(_Sc_HasAppConfigConfigurationTransform)'=='true' " />
+    <SlowCheetah.Xdt.TransformXml Source="$(AppConfig)"
+                  Transform="@(_AppConfigToTransform->'%(RelativeDir)%(Filename).$(PublishProfile)%(Extension)')"
+                  Destination="$(__SC_IntermediateAppConfig)"
+                  Condition=" '$(_Sc_HasAppConfigPublishProfileTransform)'=='true' " />
 
     <PropertyGroup Condition=" '$(_Sc_HasAppConfigTransform)'=='true' " >
       <AppConfig>$(__SC_IntermediateAppConfig)</AppConfig>


### PR DESCRIPTION
This was already implemented in 03b5df46c199e1a4f8abe158c1fdb5fdb9e2c84a (PR #85) but removed in 1c5c7ec38e440143dbd279cf1bfdad05c3b00fcf (issue #93) again.

This implementation additionally respects the case `$(Configuration) == $(PublishProfile)`.

Comments and suggestions for improvements welcome!
