### PR TITLE
Adding auto install logic

### DIFF
--- a/SlowCheetah.VisualStudio.Tests/Properties/AssemblyInfo.cs
+++ b/SlowCheetah.VisualStudio.Tests/Properties/AssemblyInfo.cs
@@ -1,4 +1,7 @@
-﻿using System.Reflection;
+﻿// Copyright (c) Sayed Ibrahim Hashimi. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See  License.md file in the project root for full license information.
+
+using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 

--- a/SlowCheetah.VisualStudio/NugetHandler/SlowCheetahNuGetManager.cs
+++ b/SlowCheetah.VisualStudio/NugetHandler/SlowCheetahNuGetManager.cs
@@ -158,6 +158,13 @@ namespace SlowCheetah.VisualStudio
             {
                 if (this.HasUserAcceptedWarningMessage())
                 {
+                    // Gets the general output pane to inform user of installation
+                    IVsOutputWindowPane outputWindow = (IVsOutputWindowPane)this.package.GetService(typeof(SVsGeneralOutputWindowPane));
+                    if (outputWindow != null)
+                    {
+                        outputWindow.OutputString(string.Format("Installing SlowCheetah NuGet package to {0} ...\n", project.Name));
+                    }
+
                     // Installs the latest version of the SlowCheetah NuGet package
                     var componentModel = (IComponentModel)this.package.GetService(typeof(SComponentModel));
                     IVsPackageInstaller2 packageInstaller = componentModel.GetService<IVsPackageInstaller2>();
@@ -168,6 +175,14 @@ namespace SlowCheetah.VisualStudio
                     {
                         Task outTask;
                         this.installTasks.TryRemove(projName, out outTask);
+                        if (t.IsCompleted)
+                        {
+                            outputWindow.OutputString(string.Format("Finished installing SlowCheetah NuGet package to {0}.\n", project.Name));
+                        }
+                        else
+                        {
+                            outputWindow.OutputString(string.Format("Error installing SlowCheetah NuGet package to {0}.\n", project.Name));
+                        }
                     });
                     this.installTasks.TryAdd(projName, installTask);
                 }

--- a/SlowCheetah.VisualStudio/NugetHandler/SlowCheetahNuGetManager.cs
+++ b/SlowCheetah.VisualStudio/NugetHandler/SlowCheetahNuGetManager.cs
@@ -138,7 +138,7 @@ namespace SlowCheetah.VisualStudio
                     IVsOutputWindowPane outputWindow = (IVsOutputWindowPane)this.package.GetService(typeof(SVsGeneralOutputWindowPane));
                     if (outputWindow != null)
                     {
-                        outputWindow.OutputString(string.Format("Installing SlowCheetah NuGet package to {0} ...\n", project.Name));
+                        outputWindow.OutputString(string.Format(Resources.Resources.NugetInstall_InstallingOutput, project.Name));
                     }
 
                     // Installs the latest version of the SlowCheetah NuGet package
@@ -146,14 +146,14 @@ namespace SlowCheetah.VisualStudio
                     IVsPackageInstaller2 packageInstaller = componentModel.GetService<IVsPackageInstaller2>();
                     TPL.Task.Run(() =>
                     {
-                        string message = "Finished installing SlowCheetah NuGet package to {0}.\n";
+                        string message = Resources.Resources.NugetInstall_FinishedOutput;
                         try
                         {
                             InstallSlowCheetahPackage(packageInstaller, project);
                         }
                         catch
                         {
-                            message = "Error installing SlowCheetah NuGet package to {0}.\n";
+                            message = Resources.Resources.NugetInstall_ErrorOutput;
                             throw;
                         }
                         finally

--- a/SlowCheetah.VisualStudio/NugetHandler/SlowCheetahNuGetManager.cs
+++ b/SlowCheetah.VisualStudio/NugetHandler/SlowCheetahNuGetManager.cs
@@ -1,0 +1,124 @@
+﻿// Copyright (c) Sayed Ibrahim Hashimi. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See  License.md file in the project root for full license information.
+
+namespace SlowCheetah.VisualStudio
+{
+    using System;
+    using System.Linq;
+    using EnvDTE;
+    using Microsoft.VisualStudio;
+    using Microsoft.VisualStudio.ComponentModelHost;
+    using Microsoft.VisualStudio.Shell.Interop;
+    using NuGet.VisualStudio;
+    using SlowCheetah.VisualStudio.Properties;
+
+    /// <summary>
+    /// Manages installations of the SlowCheetah NuGet package in the project
+    /// </summary>
+    public class SlowCheetahNuGetManager
+    {
+        private static readonly string PackageName = Settings.Default.SlowCheetahNugetPkgName;
+        private static readonly int InstallDialogDelay = 1;
+
+        private IServiceProvider package;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SlowCheetahNuGetManager"/> class.
+        /// </summary>
+        /// <param name="package">VS Package</param>
+        public SlowCheetahNuGetManager(IServiceProvider package)
+        {
+            this.package = package;
+        }
+
+        /// <summary>
+        /// Checks the SlowCheetah NuGet package on current project.
+        /// If no version is installed, prompts for install of latest version;
+        /// if an older version is detected, shows update information.
+        /// </summary>
+        /// <param name="project">Project to be verified</param>
+        public void CheckSlowCheetahInstallation(Project project)
+        {
+            if (this.IsSlowCheetahInstalled(project))
+            {
+                if (!this.IsSlowCheetahUpdated(project))
+                {
+                    INugetPackageHandler nugetHandler = NugetHandlerFactory.GetHandler(this.package);
+                    nugetHandler.ShowUpdateInfo();
+                }
+            }
+            else
+            {
+                this.InstallSlowCheetah(project);
+            }
+        }
+
+        private bool IsSlowCheetahInstalled(Project project)
+        {
+            var componentModel = (IComponentModel)this.package.GetService(typeof(SComponentModel));
+            IVsPackageInstallerServices installerServices = componentModel.GetService<IVsPackageInstallerServices>();
+            return installerServices.IsPackageInstalled(project, PackageName);
+        }
+
+        private bool IsSlowCheetahUpdated(Project project)
+        {
+            // Checks for older SC versions that require more complex update procedure
+            var componentModel = (IComponentModel)this.package.GetService(typeof(SComponentModel));
+            IVsPackageInstallerServices installerServices = componentModel.GetService<IVsPackageInstallerServices>();
+            IVsPackageMetadata scPackage =
+                    installerServices.GetInstalledPackages().First(pkg => string.Equals(pkg.Id, PackageName, StringComparison.OrdinalIgnoreCase));
+            if (scPackage != null)
+            {
+                Version ver;
+                if (Version.TryParse(scPackage.VersionString, out ver))
+                {
+                    return ver > new Version(2, 5, 15);
+                }
+            }
+
+            return false;
+        }
+
+        private void InstallSlowCheetah(Project project)
+        {
+            if (this.HasUserAcceptedWarningMessage())
+            {
+                // Creates dialog informing the user to wait for the installation to finish
+                IVsThreadedWaitDialogFactory twdFactory = this.package.GetService(typeof(SVsThreadedWaitDialogFactory)) as IVsThreadedWaitDialogFactory;
+                IVsThreadedWaitDialog2 dialog = null;
+                twdFactory?.CreateInstance(out dialog);
+                string title = Resources.Resources.NugetInstall_WaitTitle;
+                string text = Resources.Resources.NugetInstall_WaitText;
+                dialog?.StartWaitDialog(title, text, null, null, null, 0, false, true);
+
+                // Installs the latest version of the SlowCheetah NuGet package
+                var componentModel = (IComponentModel)this.package.GetService(typeof(SComponentModel));
+                IVsPackageInstaller2 packageInstaller = componentModel.GetService<IVsPackageInstaller2>();
+                packageInstaller.InstallLatestPackage(null, project, PackageName, false, false);
+
+                // Closes the wait dialog. If the dialog failed, does nothing
+                int canceled;
+                dialog?.EndWaitDialog(out canceled);
+            }
+        }
+
+        private bool HasUserAcceptedWarningMessage()
+        {
+            IVsUIShell shell = this.package.GetService(typeof(SVsUIShell)) as IVsUIShell;
+            if (shell != null)
+            {
+                // Show a message box requesting the install of the SC package
+                string title = Resources.Resources.NugetInstall_Title;
+                string message = Resources.Resources.NugetInstall_Text;
+                Guid compClass = Guid.Empty;
+                int result;
+                if (ErrorHandler.Succeeded(shell.ShowMessageBox(0, ref compClass, title, message, null, 0, OLEMSGBUTTON.OLEMSGBUTTON_YESNO, OLEMSGDEFBUTTON.OLEMSGDEFBUTTON_FIRST, OLEMSGICON.OLEMSGICON_WARNING, 1, out result)))
+                {
+                    return result == 6; // IDYES
+                }
+            }
+
+            return false;
+        }
+    }
+}

--- a/SlowCheetah.VisualStudio/Resources/Resources.Designer.cs
+++ b/SlowCheetah.VisualStudio/Resources/Resources.Designer.cs
@@ -106,6 +106,33 @@ namespace SlowCheetah.VisualStudio.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Error installing SlowCheetah NuGet package to {0}.\n.
+        /// </summary>
+        internal static string NugetInstall_ErrorOutput {
+            get {
+                return ResourceManager.GetString("NugetInstall_ErrorOutput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Finished installing SlowCheetah NuGet package to {0}.\n.
+        /// </summary>
+        internal static string NugetInstall_FinishedOutput {
+            get {
+                return ResourceManager.GetString("NugetInstall_FinishedOutput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Installing SlowCheetah NuGet package to {0} ...\n.
+        /// </summary>
+        internal static string NugetInstall_InstallingOutput {
+            get {
+                return ResourceManager.GetString("NugetInstall_InstallingOutput", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to In order to execute transform on build, you will need the SlowCheetah NuGet package. Do you want to install the package now?.
         /// </summary>
         internal static string NugetInstall_Text {
@@ -120,24 +147,6 @@ namespace SlowCheetah.VisualStudio.Resources {
         internal static string NugetInstall_Title {
             get {
                 return ResourceManager.GetString("NugetInstall_Title", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Installing the SlowCheetah NuGet package, this may take a few seconds.
-        /// </summary>
-        internal static string NugetInstall_WaitText {
-            get {
-                return ResourceManager.GetString("NugetInstall_WaitText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to SlowCheetah.
-        /// </summary>
-        internal static string NugetInstall_WaitTitle {
-            get {
-                return ResourceManager.GetString("NugetInstall_WaitTitle", resourceCulture);
             }
         }
         

--- a/SlowCheetah.VisualStudio/Resources/Resources.Designer.cs
+++ b/SlowCheetah.VisualStudio/Resources/Resources.Designer.cs
@@ -106,6 +106,42 @@ namespace SlowCheetah.VisualStudio.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to In order to execute transform on build, you will need the SlowCheetah NuGet package. Do you want to install the package now?.
+        /// </summary>
+        internal static string NugetInstall_Text {
+            get {
+                return ResourceManager.GetString("NugetInstall_Text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Install SlowCheetah NuGet package.
+        /// </summary>
+        internal static string NugetInstall_Title {
+            get {
+                return ResourceManager.GetString("NugetInstall_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Installing the SlowCheetah NuGet package, this may take a few seconds.
+        /// </summary>
+        internal static string NugetInstall_WaitText {
+            get {
+                return ResourceManager.GetString("NugetInstall_WaitText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SlowCheetah.
+        /// </summary>
+        internal static string NugetInstall_WaitTitle {
+            get {
+                return ResourceManager.GetString("NugetInstall_WaitTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to here.
         /// </summary>
         internal static string NugetUpdate_InfoBarLink {
@@ -133,38 +169,11 @@ namespace SlowCheetah.VisualStudio.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to In order to support transforms your project file will need to be modified. This will cause your project to be unloaded and then reloaded. If your project is checked into source control then it may be checked out.\n\nChoose Yes to proceed otherwise No..
-        /// </summary>
-        internal static string String_AddImportText {
-            get {
-                return ResourceManager.GetString("String_AddImportText", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Add Transform Project Import.
-        /// </summary>
-        internal static string String_AddImportTitle {
-            get {
-                return ResourceManager.GetString("String_AddImportTitle", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to {0}.{1}{2}.
         /// </summary>
         internal static string String_FormatTransformFilename {
             get {
                 return ResourceManager.GetString("String_FormatTransformFilename", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to &lt;?xml version=&quot;1.0&quot; encoding=&quot;utf-8&quot; ?&gt;\n&lt;!-- For more information on using transformations see the web.config examples at http://go.microsoft.com/fwlink/?LinkId=214134. --&gt;\n.
-        /// </summary>
-        internal static string String_TransformFileContents {
-            get {
-                return ResourceManager.GetString("String_TransformFileContents", resourceCulture);
             }
         }
         

--- a/SlowCheetah.VisualStudio/Resources/Resources.resx
+++ b/SlowCheetah.VisualStudio/Resources/Resources.resx
@@ -137,6 +137,18 @@
     <value>The transform file {0} was not found.</value>
     <comment>Error message</comment>
   </data>
+  <data name="NugetInstall_ErrorOutput" xml:space="preserve">
+    <value>Error installing SlowCheetah NuGet package to {0}.\n</value>
+    <comment>Text to be shown in the output window if there is an error with installing the SlowCheetah Nuget package</comment>
+  </data>
+  <data name="NugetInstall_FinishedOutput" xml:space="preserve">
+    <value>Finished installing SlowCheetah NuGet package to {0}.\n</value>
+    <comment>Text to be shown in the output window when the SlowCheetah Nuget package is done installing</comment>
+  </data>
+  <data name="NugetInstall_InstallingOutput" xml:space="preserve">
+    <value>Installing SlowCheetah NuGet package to {0} ...\n</value>
+    <comment>Text to be shown in the output window as the SlowCheetah NuGet package is being installed</comment>
+  </data>
   <data name="NugetInstall_Text" xml:space="preserve">
     <value>In order to execute transform on build, you will need the SlowCheetah NuGet package. Do you want to install the package now?</value>
     <comment>Text for the prompt to install the SlowCheetah NuGet package</comment>
@@ -144,14 +156,6 @@
   <data name="NugetInstall_Title" xml:space="preserve">
     <value>Install SlowCheetah NuGet package</value>
     <comment>Title for the prompt to install the SlowCheetah NuGet package</comment>
-  </data>
-  <data name="NugetInstall_WaitText" xml:space="preserve">
-    <value>Installing the SlowCheetah NuGet package, this may take a few seconds</value>
-    <comment>Text for the wait dialog on install of the NuGet package</comment>
-  </data>
-  <data name="NugetInstall_WaitTitle" xml:space="preserve">
-    <value>SlowCheetah</value>
-    <comment>Title for the wait dialog on install of the NuGet package</comment>
   </data>
   <data name="NugetUpdate_InfoBarLink" xml:space="preserve">
     <value>here</value>

--- a/SlowCheetah.VisualStudio/Resources/Resources.resx
+++ b/SlowCheetah.VisualStudio/Resources/Resources.resx
@@ -137,6 +137,22 @@
     <value>The transform file {0} was not found.</value>
     <comment>Error message</comment>
   </data>
+  <data name="NugetInstall_Text" xml:space="preserve">
+    <value>In order to execute transform on build, you will need the SlowCheetah NuGet package. Do you want to install the package now?</value>
+    <comment>Text for the prompt to install the SlowCheetah NuGet package</comment>
+  </data>
+  <data name="NugetInstall_Title" xml:space="preserve">
+    <value>Install SlowCheetah NuGet package</value>
+    <comment>Title for the prompt to install the SlowCheetah NuGet package</comment>
+  </data>
+  <data name="NugetInstall_WaitText" xml:space="preserve">
+    <value>Installing the SlowCheetah NuGet package, this may take a few seconds</value>
+    <comment>Text for the wait dialog on install of the NuGet package</comment>
+  </data>
+  <data name="NugetInstall_WaitTitle" xml:space="preserve">
+    <value>SlowCheetah</value>
+    <comment>Title for the wait dialog on install of the NuGet package</comment>
+  </data>
   <data name="NugetUpdate_InfoBarLink" xml:space="preserve">
     <value>here</value>
     <comment>Text of the link in the update info bar</comment>
@@ -149,20 +165,9 @@
     <value>https://github.com/sayedihashimi/slow-cheetah/blob/master/doc/update.md</value>
     <comment>Link to the update info for the SlowCheetah Nuget package</comment>
   </data>
-  <data name="String_AddImportText" xml:space="preserve">
-    <value>In order to support transforms your project file will need to be modified. This will cause your project to be unloaded and then reloaded. If your project is checked into source control then it may be checked out.\n\nChoose Yes to proceed otherwise No.</value>
-  </data>
-  <data name="String_AddImportTitle" xml:space="preserve">
-    <value>Add Transform Project Import</value>
-    <comment>Title for the warning dialog that you project is about to have the import added.</comment>
-  </data>
   <data name="String_FormatTransformFilename" xml:space="preserve">
     <value>{0}.{1}{2}</value>
     <comment>This is the format string for the new transform file's filename.</comment>
-  </data>
-  <data name="String_TransformFileContents" xml:space="preserve">
-    <value>&lt;?xml version="1.0" encoding="utf-8" ?&gt;\n&lt;!-- For more information on using transformations see the web.config examples at http://go.microsoft.com/fwlink/?LinkId=214134. --&gt;\n</value>
-    <comment>This is the initial contents of the transform file.</comment>
   </data>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
   <data name="TransformContents" type="System.Resources.ResXFileRef, System.Windows.Forms">

--- a/SlowCheetah.VisualStudio/SlowCheetah.VisualStudio.csproj
+++ b/SlowCheetah.VisualStudio/SlowCheetah.VisualStudio.csproj
@@ -51,6 +51,7 @@
     <Compile Include="NugetHandler\NugetHandlerFactory.cs" />
     <Compile Include="NugetHandler\LegacyNugetMessageHandler.cs" />
     <Compile Include="NugetHandler\NugetInfoBarHandler.cs" />
+    <Compile Include="NugetHandler\SlowCheetahNuGetManager.cs" />
     <Compile Include="OptionsDialogPage.cs">
       <SubType>Component</SubType>
     </Compile>

--- a/SlowCheetah.VisualStudio/SlowCheetahPackage.cs
+++ b/SlowCheetah.VisualStudio/SlowCheetahPackage.cs
@@ -67,6 +67,7 @@ namespace SlowCheetah.VisualStudio
             // initialization is the Initialize method.
             this.LogMessageWriteLineFormat("Entering constructor for: {0}", this.ToString());
             OurPackage = this;
+            this.NuGetManager = new SlowCheetahNuGetManager(this);
         }
 
         /// <summary>
@@ -75,6 +76,8 @@ namespace SlowCheetah.VisualStudio
         public static SlowCheetahPackage OurPackage { get; private set; }
 
         private IList<string> TempFilesCreated { get; } = new List<string>();
+
+        private SlowCheetahNuGetManager NuGetManager { get; }
 
         /// <summary>
         /// Gets the installation directory for the current instance of Visual Studio.
@@ -289,8 +292,7 @@ namespace SlowCheetah.VisualStudio
             if (selectedProjectItem != null)
             {
                 // Checks the SlowCheetah NuGet package installation
-                SlowCheetahNuGetManager scNugetManager = SlowCheetahNuGetManager.GetInstance(this);
-                scNugetManager.CheckSlowCheetahInstallation(hierarchy);
+                this.NuGetManager.CheckSlowCheetahInstallation(hierarchy);
 
                 // need to enure that this item has metadata TransformOnBuild set to true
                 if (buildPropertyStorage != null)
@@ -370,8 +372,7 @@ namespace SlowCheetah.VisualStudio
             }
 
             // Checks the SlowCheetah NuGet package installation
-            SlowCheetahNuGetManager scNugetManager = SlowCheetahNuGetManager.GetInstance(this);
-            scNugetManager.CheckSlowCheetahInstallation(hierarchy);
+            this.NuGetManager.CheckSlowCheetahInstallation(hierarchy);
 
             object parentIdObj;
             ErrorHandler.ThrowOnFailure(hierarchy.GetProperty(itemId, (int)__VSHPROPID.VSHPROPID_Parent, out parentIdObj));

--- a/SlowCheetah.VisualStudio/SlowCheetahPackage.cs
+++ b/SlowCheetah.VisualStudio/SlowCheetahPackage.cs
@@ -15,10 +15,8 @@ namespace SlowCheetah.VisualStudio
     using System.Xml;
     using EnvDTE;
     using Microsoft.VisualStudio;
-    using Microsoft.VisualStudio.ComponentModelHost;
     using Microsoft.VisualStudio.Shell;
     using Microsoft.VisualStudio.Shell.Interop;
-    using NuGet.VisualStudio;
     using SlowCheetah.VisualStudio.Properties;
 
     /// <summary>
@@ -57,8 +55,6 @@ namespace SlowCheetah.VisualStudio
         private static readonly string TransformOnBuild = "TransformOnBuild";
         private static readonly string IsTransformFile = "IsTransformFile";
         private static readonly string DependentUpon = "DependentUpon";
-
-        private static readonly string PkgName = Settings.Default.SlowCheetahNugetPkgName;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="SlowCheetahPackage"/> class.
@@ -292,8 +288,9 @@ namespace SlowCheetah.VisualStudio
             ProjectItem selectedProjectItem = PackageUtilities.GetAutomationFromHierarchy<ProjectItem>(hierarchy, itemid);
             if (selectedProjectItem != null)
             {
+                // Checks the SlowCheetah NuGet package installation
                 SlowCheetahNuGetManager scNugetManager = new SlowCheetahNuGetManager(this);
-                scNugetManager.CheckSlowCheetahInstallation(selectedProjectItem.ContainingProject);
+                scNugetManager.CheckSlowCheetahInstallation(hierarchy);
 
                 // need to enure that this item has metadata TransformOnBuild set to true
                 if (buildPropertyStorage != null)
@@ -372,9 +369,9 @@ namespace SlowCheetah.VisualStudio
                 return;
             }
 
-            Project currentProject = PackageUtilities.GetAutomationFromHierarchy<Project>(hierarchy, (uint)VSConstants.VSITEMID.Root);
+            // Checks the SlowCheetah NuGet package installation
             SlowCheetahNuGetManager scNugetManager = new SlowCheetahNuGetManager(this);
-            scNugetManager.CheckSlowCheetahInstallation(currentProject);
+            scNugetManager.CheckSlowCheetahInstallation(hierarchy);
 
             object parentIdObj;
             ErrorHandler.ThrowOnFailure(hierarchy.GetProperty(itemId, (int)__VSHPROPID.VSHPROPID_Parent, out parentIdObj));

--- a/SlowCheetah.VisualStudio/SlowCheetahPackage.cs
+++ b/SlowCheetah.VisualStudio/SlowCheetahPackage.cs
@@ -11,9 +11,7 @@ namespace SlowCheetah.VisualStudio
     using System.Globalization;
     using System.IO;
     using System.Linq;
-    using System.Reflection;
     using System.Runtime.InteropServices;
-    using System.Text.RegularExpressions;
     using System.Xml;
     using EnvDTE;
     using Microsoft.VisualStudio;
@@ -56,11 +54,6 @@ namespace SlowCheetah.VisualStudio
     [SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1650:ElementDocumentationMustBeSpelledCorrectly", Justification = "pkgdef, VS and vsixmanifest are valid VS terms")]
     public sealed class SlowCheetahPackage : Package
     {
-        /// <summary>
-        /// SlowCheetahPackage GUID string.
-        /// </summary>
-        public const string PackageGuidString = "9f2f5f20-3e0c-4c4d-9064-0351c3adec59";
-
         private static readonly string TransformOnBuild = "TransformOnBuild";
         private static readonly string IsTransformFile = "IsTransformFile";
         private static readonly string DependentUpon = "DependentUpon";

--- a/SlowCheetah.VisualStudio/SlowCheetahPackage.cs
+++ b/SlowCheetah.VisualStudio/SlowCheetahPackage.cs
@@ -289,7 +289,7 @@ namespace SlowCheetah.VisualStudio
             if (selectedProjectItem != null)
             {
                 // Checks the SlowCheetah NuGet package installation
-                SlowCheetahNuGetManager scNugetManager = new SlowCheetahNuGetManager(this);
+                SlowCheetahNuGetManager scNugetManager = SlowCheetahNuGetManager.GetInstance(this);
                 scNugetManager.CheckSlowCheetahInstallation(hierarchy);
 
                 // need to enure that this item has metadata TransformOnBuild set to true
@@ -370,7 +370,7 @@ namespace SlowCheetah.VisualStudio
             }
 
             // Checks the SlowCheetah NuGet package installation
-            SlowCheetahNuGetManager scNugetManager = new SlowCheetahNuGetManager(this);
+            SlowCheetahNuGetManager scNugetManager = SlowCheetahNuGetManager.GetInstance(this);
             scNugetManager.CheckSlowCheetahInstallation(hierarchy);
 
             object parentIdObj;


### PR DESCRIPTION
If no previous installation of SlowCheetah is detected, the option to auto install the latest version of the package is displayed to the user.
Added logic to detect even older versions of SlowCheetah, i.e. before NuGet.