### PR TITLE
Auto uninstall of older SlowCheetah versions

### DIFF
--- a/SlowCheetah.VisualStudio/NugetHandler/SlowCheetahNuGetManager.cs
+++ b/SlowCheetah.VisualStudio/NugetHandler/SlowCheetahNuGetManager.cs
@@ -199,9 +199,9 @@ namespace SlowCheetah.VisualStudio
 
         private void UpdateSlowCheetah(Project project)
         {
-            // This is done on the UI thread because changes are made to thre project file,
-            // Causing it to be reloaded. To avoid conflicts with NuGet installation,
-            // The update is done sequentially
+            // This is done on the UI thread because changes are made to the project file,
+            // causing it to be reloaded. To avoid conflicts with NuGet installation,
+            // the update is done sequentially
             if (this.HasUserAcceptedWarningMessage(Resources.Resources.NugetUpdate_Title, Resources.Resources.NugetUpdate_Text))
             {
                 // Creates dialog informing the user to wait for the installation to finish

--- a/SlowCheetah.VisualStudio/NugetHandler/SlowCheetahNuGetManager.cs
+++ b/SlowCheetah.VisualStudio/NugetHandler/SlowCheetahNuGetManager.cs
@@ -109,7 +109,7 @@ namespace SlowCheetah.VisualStudio
 
         private bool IsSlowCheetahUpdated(Project project)
         {
-            // Checks for older SC versions that require more complex update procedure
+            // Checks for older SC versions that require more complex update procedure.
             IVsPackageInstallerServices installerServices = GetInstallerServices(this.package);
             IVsPackageMetadata scPackage =
                     installerServices.GetInstalledPackages().FirstOrDefault(pkg => string.Equals(pkg.Id, PackageName, StringComparison.OrdinalIgnoreCase));
@@ -190,7 +190,7 @@ namespace SlowCheetah.VisualStudio
                 {
                     lock (this.syncObject)
                     {
-                        // If the user refuses to install, the task should not added
+                        // If the user refuses to install, the task should not be added
                         this.installTasks.Remove(projName);
                     }
                 }
@@ -199,6 +199,9 @@ namespace SlowCheetah.VisualStudio
 
         private void UpdateSlowCheetah(Project project)
         {
+            // This is done on the UI thread because changes are made to thre project file,
+            // Causing it to be reloaded. To avoid conflicts with NuGet installation,
+            // The update is done sequentially
             if (this.HasUserAcceptedWarningMessage(Resources.Resources.NugetUpdate_Title, Resources.Resources.NugetUpdate_Text))
             {
                 // Creates dialog informing the user to wait for the installation to finish

--- a/SlowCheetah.VisualStudio/Resources/Resources.Designer.cs
+++ b/SlowCheetah.VisualStudio/Resources/Resources.Designer.cs
@@ -169,6 +169,24 @@ namespace SlowCheetah.VisualStudio.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to It seems that you have an older version of the SlowCheetah package installed. In order to avoid conflicts, you should update you package. Doing so may cause changes to your project file. Do you wish to update now?.
+        /// </summary>
+        internal static string NugetUpdate_Text {
+            get {
+                return ResourceManager.GetString("NugetUpdate_Text", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Update SlowCheetah NuGet package.
+        /// </summary>
+        internal static string NugetUpdate_Title {
+            get {
+                return ResourceManager.GetString("NugetUpdate_Title", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0}.{1}{2}.
         /// </summary>
         internal static string String_FormatTransformFilename {

--- a/SlowCheetah.VisualStudio/Resources/Resources.Designer.cs
+++ b/SlowCheetah.VisualStudio/Resources/Resources.Designer.cs
@@ -106,7 +106,7 @@ namespace SlowCheetah.VisualStudio.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Error installing SlowCheetah NuGet package to {0}.\n.
+        ///   Looks up a localized string similar to Error installing SlowCheetah NuGet package to {0}..
         /// </summary>
         internal static string NugetInstall_ErrorOutput {
             get {
@@ -115,7 +115,7 @@ namespace SlowCheetah.VisualStudio.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Finished installing SlowCheetah NuGet package to {0}.\n.
+        ///   Looks up a localized string similar to Finished installing SlowCheetah NuGet package to {0}..
         /// </summary>
         internal static string NugetInstall_FinishedOutput {
             get {
@@ -124,7 +124,7 @@ namespace SlowCheetah.VisualStudio.Resources {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Installing SlowCheetah NuGet package to {0} ...\n.
+        ///   Looks up a localized string similar to Installing SlowCheetah NuGet package to {0} ....
         /// </summary>
         internal static string NugetInstall_InstallingOutput {
             get {

--- a/SlowCheetah.VisualStudio/Resources/Resources.Designer.cs
+++ b/SlowCheetah.VisualStudio/Resources/Resources.Designer.cs
@@ -196,6 +196,24 @@ namespace SlowCheetah.VisualStudio.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Updating the SlowCheetah NuGet package, this may take a few seconds.
+        /// </summary>
+        internal static string NugetUpdate_WaitText {
+            get {
+                return ResourceManager.GetString("NugetUpdate_WaitText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to SlowCheetah Update.
+        /// </summary>
+        internal static string NugetUpdate_WaitTitle {
+            get {
+                return ResourceManager.GetString("NugetUpdate_WaitTitle", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to {0}.{1}{2}.
         /// </summary>
         internal static string String_FormatTransformFilename {

--- a/SlowCheetah.VisualStudio/Resources/Resources.resx
+++ b/SlowCheetah.VisualStudio/Resources/Resources.resx
@@ -177,6 +177,14 @@
     <value>Update SlowCheetah NuGet package</value>
     <comment>Title for the prompt to update the SlowCheetah NuGet package</comment>
   </data>
+  <data name="NugetUpdate_WaitText" xml:space="preserve">
+    <value>Updating the SlowCheetah NuGet package, this may take a few seconds</value>
+    <comment>Text for the wait dialog on update of the NuGet package</comment>
+  </data>
+  <data name="NugetUpdate_WaitTitle" xml:space="preserve">
+    <value>SlowCheetah Update</value>
+    <comment>Title for the wait dialog on update of the NuGet package</comment>
+  </data>
   <data name="String_FormatTransformFilename" xml:space="preserve">
     <value>{0}.{1}{2}</value>
     <comment>This is the format string for the new transform file's filename.</comment>

--- a/SlowCheetah.VisualStudio/Resources/Resources.resx
+++ b/SlowCheetah.VisualStudio/Resources/Resources.resx
@@ -138,15 +138,15 @@
     <comment>Error message</comment>
   </data>
   <data name="NugetInstall_ErrorOutput" xml:space="preserve">
-    <value>Error installing SlowCheetah NuGet package to {0}.\n</value>
+    <value>Error installing SlowCheetah NuGet package to {0}.</value>
     <comment>Text to be shown in the output window if there is an error with installing the SlowCheetah Nuget package</comment>
   </data>
   <data name="NugetInstall_FinishedOutput" xml:space="preserve">
-    <value>Finished installing SlowCheetah NuGet package to {0}.\n</value>
+    <value>Finished installing SlowCheetah NuGet package to {0}.</value>
     <comment>Text to be shown in the output window when the SlowCheetah Nuget package is done installing</comment>
   </data>
   <data name="NugetInstall_InstallingOutput" xml:space="preserve">
-    <value>Installing SlowCheetah NuGet package to {0} ...\n</value>
+    <value>Installing SlowCheetah NuGet package to {0} ...</value>
     <comment>Text to be shown in the output window as the SlowCheetah NuGet package is being installed</comment>
   </data>
   <data name="NugetInstall_Text" xml:space="preserve">

--- a/SlowCheetah.VisualStudio/Resources/Resources.resx
+++ b/SlowCheetah.VisualStudio/Resources/Resources.resx
@@ -171,9 +171,11 @@
   </data>
   <data name="NugetUpdate_Text" xml:space="preserve">
     <value>It seems that you have an older version of the SlowCheetah package installed. In order to avoid conflicts, you should update you package. Doing so may cause changes to your project file. Do you wish to update now?</value>
+    <comment>Text for the prompt to update the SlowCheetah NuGet package</comment>
   </data>
   <data name="NugetUpdate_Title" xml:space="preserve">
     <value>Update SlowCheetah NuGet package</value>
+    <comment>Title for the prompt to update the SlowCheetah NuGet package</comment>
   </data>
   <data name="String_FormatTransformFilename" xml:space="preserve">
     <value>{0}.{1}{2}</value>

--- a/SlowCheetah.VisualStudio/Resources/Resources.resx
+++ b/SlowCheetah.VisualStudio/Resources/Resources.resx
@@ -165,6 +165,12 @@
     <value>https://github.com/sayedihashimi/slow-cheetah/blob/master/doc/update.md</value>
     <comment>Link to the update info for the SlowCheetah Nuget package</comment>
   </data>
+  <data name="NugetUpdate_Text" xml:space="preserve">
+    <value>It seems that you have an older version of the SlowCheetah package installed. In order to avoid conflicts, you should update you package. Doing so may cause changes to your project file. Do you wish to update now?</value>
+  </data>
+  <data name="NugetUpdate_Title" xml:space="preserve">
+    <value>Update SlowCheetah NuGet package</value>
+  </data>
   <data name="String_FormatTransformFilename" xml:space="preserve">
     <value>{0}.{1}{2}</value>
     <comment>This is the format string for the new transform file's filename.</comment>


### PR DESCRIPTION
Adds logic for automatic uninstall of older versions of SlowCheetah. If an older versions is detected (by verifying some groups in the project file), the user is prompted to update, including editing of the project file and updating the NuGet package.